### PR TITLE
Allowing embedding images from remote hosts

### DIFF
--- a/.github/workflows/laravel-package.yml
+++ b/.github/workflows/laravel-package.yml
@@ -1,0 +1,25 @@
+name: Testing Laravel Package
+
+on: [push, pull_request]
+
+jobs:
+  laravel:
+    name: Laravel Package (PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }})
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.2']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Install Composer dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      - name: Check styling with PHP CS Fixer
+        uses: StephaneBour/actions-php-cs-fixer@1.0
+      - name: Test with phpunit
+        run: vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-[![Packagist](https://img.shields.io/packagist/v/eduardokum/laravel-mail-auto-embed.svg?style=flat-square)](https://github.com/eduardokum/laravel-mail-auto-embed)
-[![Packagist](https://img.shields.io/packagist/dt/eduardokum/laravel-mail-auto-embed.svg?style=flat-square)](https://github.com/eduardokum/laravel-mail-auto-embed)
-[![Packagist](https://img.shields.io/packagist/l/eduardokum/laravel-mail-auto-embed.svg?style=flat-square)](https://github.com/eduardokum/laravel-mail-auto-embed)
-[![GitHub forks](https://img.shields.io/github/forks/eduardokum/laravel-mail-auto-embed.svg?style=social&label=Fork)](https://github.com/eduardokum/laravel-mail-auto-embed)
+[![Actions Status](https://github.com/rsvpify/laravel-mail-auto-embed/workflows/Testing%20Laravel%20Package/badge.svg)](https://github.com/rsvpify/laravel-mail-auto-embed/actions)
 
 # Laravel Mail Auto Embed
 
@@ -10,7 +7,7 @@
 
 You can install the package via composer:
 ```bash
-$ composer require eduardokum/laravel-mail-auto-embed
+$ composer require rsvpify/laravel-mail-auto-embed
 ```
 
 This package uses Laravel 5.5 Package Auto-Discovery.<br>
@@ -19,7 +16,7 @@ For previous versions of Laravel, you need to add the following Service Provider
 ```php
 $providers = [
     ...
-    \Eduardokum\LaravelMailAutoEmbed\ServiceProvider::class,
+    \Rsvpify\LaravelMailAutoEmbed\ServiceProvider::class,
     ...
  ];
 ```
@@ -86,7 +83,7 @@ For local resources that are not available publicly, use `file://` urls, example
 The defaults are set in `config/mail-auto-embed.php`. You can copy this file to your own config directory to modify the values using this command:
 
 ```shell
-php artisan vendor:publish --provider="Eduardokum\LaravelMailAutoEmbed\ServiceProvider"
+php artisan vendor:publish --provider="Rsvpify\LaravelMailAutoEmbed\ServiceProvider"
 ```
 
 ### Explicit embedding configuration
@@ -142,7 +139,7 @@ In that case, make the entities you want to embed implement the `EmbeddableEntit
 ```php
 namespace App\Models;
 
-use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
+use Rsvpify\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 use Illuminate\Database\Eloquent\Model;
 
 class Picture extends Model implements EmbeddableEntity

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "eduardokum/laravel-mail-auto-embed",
+    "name": "rsvpify/laravel-mail-auto-embed",
     "description": "Library for embed images in emails automatically",
     "keywords": [
-        "eduardokum",
+        "rsvpify",
         "laravel-mail-auto-embed"
     ],
-    "homepage": "https://github.com/eduardokum/laravel-mail-auto-embed",
+    "homepage": "https://github.com/rsvpify/laravel-mail-auto-embed",
     "license": "MIT",
     "authors": [
         {
-            "name": "Eduardo Gusmão",
-            "email": "eduguscontra3@hotmail.com"
+            "name": "Bryan Miller",
+            "email": "bryan@kirschbaumdevelopment.com"
         }
     ],
     "require": {
@@ -25,18 +25,18 @@
     },
     "autoload": {
         "psr-4": {
-            "Eduardokum\\LaravelMailAutoEmbed\\": "src"
+            "Rsvpify\\LaravelMailAutoEmbed\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Eduardokum\\LaravelMailAutoEmbed\\Tests\\": "tests"
+            "Rsvpify\\LaravelMailAutoEmbed\\Tests\\": "tests"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "Eduardokum\\LaravelMailAutoEmbed\\ServiceProvider"
+                "Rsvpify\\LaravelMailAutoEmbed\\ServiceProvider"
             ]
         }
     }

--- a/config/mail-auto-embed.php
+++ b/config/mail-auto-embed.php
@@ -25,4 +25,5 @@ return [
 
     'method' => env('MAIL_AUTO_EMBED_METHOD', 'attachment'),
 
+    'whitelist' => explode(',', env('MAIL_AUTO_EMBED_WHITELIST', '')),
 ];

--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -5,6 +5,7 @@ namespace Eduardokum\LaravelMailAutoEmbed\Embedder;
 use Swift_Image;
 use Swift_Message;
 use Swift_EmbeddedFile;
+use Illuminate\Support\Str;
 use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 
 class AttachmentEmbedder extends Embedder
@@ -61,7 +62,7 @@ class AttachmentEmbedder extends Embedder
             curl_close($ch);
             if ($httpcode == 200) {
                 return $this->embed(
-                    new Swift_Image($raw, str_random(10), $contentType)
+                    new Swift_Image($raw, Str::random(10), $contentType)
                 );
             }
         }

--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -97,10 +97,10 @@ class AttachmentEmbedder extends Embedder
             return false;
         }
 
-        $whitelisted_urls = config('mail-auto-embed.whitelist', []);
+        $whitelistedUrls = config('mail-auto-embed.whitelist', []);
 
-        foreach ($whitelisted_urls as $whitelist_url) {
-            if (strpos($url, $whitelist_url) === 0) {
+        foreach ($whitelistedUrls as $whitelistedUrl) {
+            if (strpos($url, $whitelistedUrl) === 0) {
                 return true;
             }
         }

--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -17,6 +17,7 @@ class AttachmentEmbedder extends Embedder
 
     /**
      * AttachmentEmbedder constructor.
+     *
      * @param  Swift_Message $message
      */
     public function __construct(Swift_Message $message)
@@ -31,7 +32,7 @@ class AttachmentEmbedder extends Embedder
     {
         $filePath = str_replace(url('/'), public_path('/'), $url);
 
-        if ( ! file_exists($filePath)) {
+        if (! file_exists($filePath)) {
             if ($embeddedFromRemoteUrl = $this->fromRemoteUrl($filePath)) {
                 return $embeddedFromRemoteUrl;
             }
@@ -60,6 +61,7 @@ class AttachmentEmbedder extends Embedder
             $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
             curl_close($ch);
+
             if ($httpcode == 200) {
                 return $this->embed(
                     new Swift_Image($raw, Str::random(10), $contentType)
@@ -86,6 +88,7 @@ class AttachmentEmbedder extends Embedder
 
     /**
      * @param  Swift_EmbeddedFile  $attachment
+     *
      * @return string
      */
     protected function embed(Swift_EmbeddedFile $attachment)
@@ -93,16 +96,17 @@ class AttachmentEmbedder extends Embedder
         return $this->message->embed($attachment);
     }
 
-
     /**
      * @param  string $url
-     * @return boolean
+     *
+     * @return bool
      */
     protected function isUrlInWhitelist($url)
     {
         $whitelisted_urls = config('mail-auto-embed.whitelist', []);
-        foreach($whitelisted_urls as $whitelist_url) {
-            if(strpos($url, $whitelist_url) === 0) {
+
+        foreach ($whitelisted_urls as $whitelist_url) {
+            if (strpos($url, $whitelist_url) === 0) {
                 return true;
             }
         }

--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -48,7 +48,7 @@ class AttachmentEmbedder extends Embedder
      */
     public function fromRemoteUrl($url)
     {
-        if (strpos($url, 'http') === 0) {
+        if (strpos($url, 'http') === 0 && $this->isUrlInWhitelist($url)) {
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_HEADER, 0);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -90,5 +90,22 @@ class AttachmentEmbedder extends Embedder
     protected function embed(Swift_EmbeddedFile $attachment)
     {
         return $this->message->embed($attachment);
+    }
+
+
+    /**
+     * @param  string $url
+     * @return boolean
+     */
+    protected function isUrlInWhitelist($url)
+    {
+        $whitelisted_urls = config('mail-auto-embed.whitelist', []);
+        foreach($whitelisted_urls as $whitelist_url) {
+            if(strpos($url, $whitelist_url) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -50,7 +50,7 @@ class AttachmentEmbedder extends Embedder
      */
     public function fromRemoteUrl($url)
     {
-        if (strpos($url, 'http') === 0 && $this->isUrlInWhitelist($url)) {
+        if ($this->isUrlInWhitelist($url)) {
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_HEADER, 0);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -87,22 +87,16 @@ class AttachmentEmbedder extends Embedder
     }
 
     /**
-     * @param  Swift_EmbeddedFile  $attachment
-     *
-     * @return string
-     */
-    protected function embed(Swift_EmbeddedFile $attachment)
-    {
-        return $this->message->embed($attachment);
-    }
-
-    /**
      * @param  string $url
      *
      * @return bool
      */
-    protected function isUrlInWhitelist($url)
+    public function isUrlInWhitelist($url)
     {
+        if (strpos($url, 'http') !== 0) {
+            return false;
+        }
+
         $whitelisted_urls = config('mail-auto-embed.whitelist', []);
 
         foreach ($whitelisted_urls as $whitelist_url) {
@@ -112,5 +106,15 @@ class AttachmentEmbedder extends Embedder
         }
 
         return false;
+    }
+
+    /**
+     * @param  Swift_EmbeddedFile  $attachment
+     *
+     * @return string
+     */
+    protected function embed(Swift_EmbeddedFile $attachment)
+    {
+        return $this->message->embed($attachment);
     }
 }

--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Embedder;
 
 use Swift_Image;
 use Swift_Message;
 use Swift_EmbeddedFile;
 use Illuminate\Support\Str;
-use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
+use Rsvpify\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 
 class AttachmentEmbedder extends Embedder
 {

--- a/src/Embedder/Base64Embedder.php
+++ b/src/Embedder/Base64Embedder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Embedder;
 
-use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
+use Rsvpify\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 
 class Base64Embedder extends Embedder
 {

--- a/src/Embedder/Embedder.php
+++ b/src/Embedder/Embedder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Embedder;
 
 abstract class Embedder implements UrlEmbedder, EntityEmbedder
 {

--- a/src/Embedder/Embedder.php
+++ b/src/Embedder/Embedder.php
@@ -4,5 +4,4 @@ namespace Rsvpify\LaravelMailAutoEmbed\Embedder;
 
 abstract class Embedder implements UrlEmbedder, EntityEmbedder
 {
-
 }

--- a/src/Embedder/EntityEmbedder.php
+++ b/src/Embedder/EntityEmbedder.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Embedder;
 
-use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
+use Rsvpify\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 
 interface EntityEmbedder
 {

--- a/src/Embedder/UrlEmbedder.php
+++ b/src/Embedder/UrlEmbedder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Embedder;
 
 interface UrlEmbedder
 {

--- a/src/Listeners/SwiftEmbedImages.php
+++ b/src/Listeners/SwiftEmbedImages.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Listeners;
+namespace Rsvpify\LaravelMailAutoEmbed\Listeners;
 
-use Eduardokum\LaravelMailAutoEmbed\Embedder\AttachmentEmbedder;
-use Eduardokum\LaravelMailAutoEmbed\Embedder\Base64Embedder;
-use Eduardokum\LaravelMailAutoEmbed\Embedder\Embedder;
-use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
+use Rsvpify\LaravelMailAutoEmbed\Embedder\AttachmentEmbedder;
+use Rsvpify\LaravelMailAutoEmbed\Embedder\Base64Embedder;
+use Rsvpify\LaravelMailAutoEmbed\Embedder\Embedder;
+use Rsvpify\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 use ReflectionClass;
 use Swift_Events_SendEvent;
 use Swift_Events_SendListener;

--- a/src/Models/EmbeddableEntity.php
+++ b/src/Models/EmbeddableEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Models;
+namespace Rsvpify\LaravelMailAutoEmbed\Models;
 
 interface EmbeddableEntity
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed;
+namespace Rsvpify\LaravelMailAutoEmbed;
 
-use Eduardokum\LaravelMailAutoEmbed\Listeners\SwiftEmbedImages;
+use Rsvpify\LaravelMailAutoEmbed\Listeners\SwiftEmbedImages;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 

--- a/tests/Embedder/AttachmentEmbedderTest.php
+++ b/tests/Embedder/AttachmentEmbedderTest.php
@@ -19,25 +19,25 @@ class AttachmentEmbedderTest extends TestCase
     /**
      * @test
      */
-    public function whitelisted_domains_return_image()
+    public function whitelisted_domains_are_verified()
     {
         config(['mail-auto-embed.whitelist' => [
-            'http://example.com',
+            'https://placehold.it',
         ]]);
 
-        $this->assertNotNull(app(AttachmentEmbedder::class)->fromRemoteUrl('http://example.com'));
+        $this->assertTrue(app(AttachmentEmbedder::class)->isUrlInWhitelist('https://placehold.it/200?text=event%20logo'));
     }
 
     /**
      * @test
      */
-    public function domains_must_be_whitelisted()
+    public function non_whitelisted_domains_are_denied()
     {
         config(['mail-auto-embed.whitelist' => [
             'http://example.com',
         ]]);
 
-        $this->assertNull(app(AttachmentEmbedder::class)->fromRemoteUrl('http://not-whitelisted.com'));
+        $this->assertFalse(app(AttachmentEmbedder::class)->isUrlInWhitelist('https://placehold.it/200?text=event%20logo'));
     }
 
     /**

--- a/tests/Embedder/AttachmentEmbedderTest.php
+++ b/tests/Embedder/AttachmentEmbedderTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Tests\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Tests\Embedder;
 
-use Eduardokum\LaravelMailAutoEmbed\Embedder\AttachmentEmbedder;
-use Eduardokum\LaravelMailAutoEmbed\Tests\fixtures\PictureEntity;
-use Eduardokum\LaravelMailAutoEmbed\Tests\TestCase;
+use Rsvpify\LaravelMailAutoEmbed\Embedder\AttachmentEmbedder;
+use Rsvpify\LaravelMailAutoEmbed\Tests\fixtures\PictureEntity;
+use Rsvpify\LaravelMailAutoEmbed\Tests\TestCase;
 use Swift_EmbeddedFile;
 use Swift_Message;
 

--- a/tests/Embedder/Base64EmbedderTest.php
+++ b/tests/Embedder/Base64EmbedderTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Tests\Embedder;
+namespace Rsvpify\LaravelMailAutoEmbed\Tests\Embedder;
 
-use Eduardokum\LaravelMailAutoEmbed\Embedder\Base64Embedder;
-use Eduardokum\LaravelMailAutoEmbed\Tests\fixtures\PictureEntity;
-use Eduardokum\LaravelMailAutoEmbed\Tests\TestCase;
+use Rsvpify\LaravelMailAutoEmbed\Embedder\Base64Embedder;
+use Rsvpify\LaravelMailAutoEmbed\Tests\fixtures\PictureEntity;
+use Rsvpify\LaravelMailAutoEmbed\Tests\TestCase;
 
 class Base64EmbedderTest extends TestCase
 {

--- a/tests/Embedder/Base64EmbedderTest.php
+++ b/tests/Embedder/Base64EmbedderTest.php
@@ -2,19 +2,12 @@
 
 namespace Rsvpify\LaravelMailAutoEmbed\Tests\Embedder;
 
+use Rsvpify\LaravelMailAutoEmbed\Tests\TestCase;
 use Rsvpify\LaravelMailAutoEmbed\Embedder\Base64Embedder;
 use Rsvpify\LaravelMailAutoEmbed\Tests\fixtures\PictureEntity;
-use Rsvpify\LaravelMailAutoEmbed\Tests\TestCase;
 
 class Base64EmbedderTest extends TestCase
 {
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->embedder = new Base64Embedder();
-    }
-
     /**
      * @test
      */
@@ -39,5 +32,12 @@ class Base64EmbedderTest extends TestCase
         $result = $embedder->fromEntity($picture);
 
         $this->assertStringStartsWith('data:image/png;base64,', $result);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->embedder = new Base64Embedder();
     }
 }

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -2,6 +2,10 @@
 
 namespace Rsvpify\LaravelMailAutoEmbed\Tests;
 
+use Swift_Message;
+use Swift_Events_SendEvent;
+use Swift_Transport_NullTransport;
+use Swift_Events_SimpleEventDispatcher;
 use Rsvpify\LaravelMailAutoEmbed\Listeners\SwiftEmbedImages;
 
 class MailTest extends TestCase
@@ -163,25 +167,25 @@ HTML;
     /**
      * @param  string  $htmlMessage
      *
-     * @return \Swift_Message
+     * @return Swift_Message
      */
     private function createSwiftMessage($htmlMessage)
     {
-        $message = new \Swift_Message('test', $htmlMessage);
+        $message = new Swift_Message('test', $htmlMessage);
 
         return $message;
     }
 
     /**
-     * @param  \Swift_Message  $message
+     * @param  Swift_Message  $message
      *
-     * @return \Swift_Events_SendEvent
+     * @return Swift_Events_SendEvent
      */
-    private function createSwiftEvent(\Swift_Message $message)
+    private function createSwiftEvent(Swift_Message $message)
     {
-        $dispatcher = new \Swift_Events_SimpleEventDispatcher();
-        $transport = new \Swift_Transport_NullTransport($dispatcher);
-        $event = new \Swift_Events_SendEvent($transport, $message);
+        $dispatcher = new Swift_Events_SimpleEventDispatcher();
+        $transport = new Swift_Transport_NullTransport($dispatcher);
+        $event = new Swift_Events_SendEvent($transport, $message);
 
         return $event;
     }
@@ -190,7 +194,7 @@ HTML;
      * @param  string  $htmlMessage
      * @param  array   $options
      *
-     * @return \Swift_Message
+     * @return Swift_Message
      */
     private function handleBeforeSendPerformedEvent($htmlMessage, $options)
     {

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -7,45 +7,6 @@ use Rsvpify\LaravelMailAutoEmbed\Listeners\SwiftEmbedImages;
 class MailTest extends TestCase
 {
     /**
-     * @param  string  $htmlMessage
-     * @return \Swift_Message
-     */
-    private function createSwiftMessage($htmlMessage)
-    {
-        $message = new \Swift_Message('test', $htmlMessage);
-
-        return $message;
-    }
-
-    /**
-     * @param  \Swift_Message  $message
-     * @return \Swift_Events_SendEvent
-     */
-    private function createSwiftEvent(\Swift_Message $message)
-    {
-        $dispatcher = new \Swift_Events_SimpleEventDispatcher();
-        $transport = new \Swift_Transport_NullTransport($dispatcher);
-        $event = new \Swift_Events_SendEvent($transport, $message);
-
-        return $event;
-    }
-
-    /**
-     * @param  string  $htmlMessage
-     * @param  array   $options
-     * @return \Swift_Message
-     */
-    private function handleBeforeSendPerformedEvent($htmlMessage, $options)
-    {
-        $message = $this->createSwiftMessage($htmlMessage);
-
-        $embedPlugin = new SwiftEmbedImages($options);
-        $embedPlugin->beforeSendPerformed($this->createSwiftEvent($message));
-
-        return $message;
-    }
-
-    /**
      * @test
      */
     public function images_are_automatically_embedded_when_enabled()
@@ -60,8 +21,8 @@ HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'attachment']);
 
-        $this->assertContains('<!-- url                --><img src="cid:',    $message->getBody());
-        $this->assertContains('<!-- url line break     --><img src="cid:',    $message->getBody());
+        $this->assertContains('<!-- url                --><img src="cid:', $message->getBody());
+        $this->assertContains('<!-- url line break     --><img src="cid:', $message->getBody());
         $this->assertContains('<!--                    entity --><img src="cid:', $message->getBody());
     }
 
@@ -77,7 +38,7 @@ HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'attachment']);
 
-        $this->assertContains('<!-- embed --><img src="cid:',                      $message->getBody());
+        $this->assertContains('<!-- embed --><img src="cid:', $message->getBody());
         $this->assertContains('<!-- skip  --><img src="http://localhost/test.png', $message->getBody());
     }
 
@@ -94,7 +55,7 @@ HTML;
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => false, 'method' => 'attachment']);
 
         $this->assertContains('<!-- ignore --><img src="http://localhost/test.png', $message->getBody());
-        $this->assertContains('<!-- embed  --><img src="cid:',                      $message->getBody());
+        $this->assertContains('<!-- embed  --><img src="cid:', $message->getBody());
     }
 
     /**
@@ -109,7 +70,7 @@ HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'attachment']);
 
-        $this->assertContains('<!-- attachment --><img src="cid:',                   $message->getBody());
+        $this->assertContains('<!-- attachment --><img src="cid:', $message->getBody());
         $this->assertContains('<!-- base64     --><img src="data:image/png;base64,', $message->getBody());
     }
 
@@ -125,7 +86,7 @@ HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'base64']);
 
-        $this->assertContains('<!-- attachment --><img src="cid:',                   $message->getBody());
+        $this->assertContains('<!-- attachment --><img src="cid:', $message->getBody());
         $this->assertContains('<!-- base64     --><img src="data:image/png;base64,', $message->getBody());
     }
 
@@ -135,7 +96,7 @@ HTML;
     public function embed_fails_gracefully_with_attachments()
     {
         config(['mail-auto-embed.whitelist' => [
-            'http://example.com'
+            'http://example.com',
         ]]);
 
         $htmlMessage = <<<HTML
@@ -150,12 +111,12 @@ HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'attachment']);
 
-        $this->assertContains('<!-- host           --><img src="http://example.com/test.png',                                              $message->getBody());
-        $this->assertContains('<!-- image          --><img src="http://localhost/other.png',                                               $message->getBody());
-        $this->assertContains('<!-- source         --><img src="whatever',                                                                 $message->getBody());
-        $this->assertContains('<!-- syntax         --><img src="embed:whatever',                                                           $message->getBody());
-        $this->assertContains('<!-- class          --><img src="embed:WrongEntityClassName:1',                                             $message->getBody());
-        $this->assertContains('<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1',   $message->getBody());
+        $this->assertContains('<!-- host           --><img src="http://example.com/test.png', $message->getBody());
+        $this->assertContains('<!-- image          --><img src="http://localhost/other.png', $message->getBody());
+        $this->assertContains('<!-- source         --><img src="whatever', $message->getBody());
+        $this->assertContains('<!-- syntax         --><img src="embed:whatever', $message->getBody());
+        $this->assertContains('<!-- class          --><img src="embed:WrongEntityClassName:1', $message->getBody());
+        $this->assertContains('<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1', $message->getBody());
         $this->assertContains('<!-- not found      --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9', $message->getBody());
     }
 
@@ -176,12 +137,12 @@ HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'base64']);
 
-        $this->assertContains('<!-- host           --><img src="http://example.com/test.png',                                              $message->getBody());
-        $this->assertContains('<!-- image          --><img src="http://localhost/other.png',                                               $message->getBody());
-        $this->assertContains('<!-- source         --><img src="whatever',                                                                 $message->getBody());
-        $this->assertContains('<!-- syntax         --><img src="embed:whatever',                                                           $message->getBody());
-        $this->assertContains('<!-- class          --><img src="embed:WrongEntityClassName:1',                                             $message->getBody());
-        $this->assertContains('<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1',   $message->getBody());
+        $this->assertContains('<!-- host           --><img src="http://example.com/test.png', $message->getBody());
+        $this->assertContains('<!-- image          --><img src="http://localhost/other.png', $message->getBody());
+        $this->assertContains('<!-- source         --><img src="whatever', $message->getBody());
+        $this->assertContains('<!-- syntax         --><img src="embed:whatever', $message->getBody());
+        $this->assertContains('<!-- class          --><img src="embed:WrongEntityClassName:1', $message->getBody());
+        $this->assertContains('<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1', $message->getBody());
         $this->assertContains('<!-- not found      --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9', $message->getBody());
     }
 
@@ -197,5 +158,47 @@ HTML;
         $this->assertTrue(
             $embedPlugin->sendPerformed($this->createSwiftEvent($message))
         );
+    }
+
+    /**
+     * @param  string  $htmlMessage
+     *
+     * @return \Swift_Message
+     */
+    private function createSwiftMessage($htmlMessage)
+    {
+        $message = new \Swift_Message('test', $htmlMessage);
+
+        return $message;
+    }
+
+    /**
+     * @param  \Swift_Message  $message
+     *
+     * @return \Swift_Events_SendEvent
+     */
+    private function createSwiftEvent(\Swift_Message $message)
+    {
+        $dispatcher = new \Swift_Events_SimpleEventDispatcher();
+        $transport = new \Swift_Transport_NullTransport($dispatcher);
+        $event = new \Swift_Events_SendEvent($transport, $message);
+
+        return $event;
+    }
+
+    /**
+     * @param  string  $htmlMessage
+     * @param  array   $options
+     *
+     * @return \Swift_Message
+     */
+    private function handleBeforeSendPerformedEvent($htmlMessage, $options)
+    {
+        $message = $this->createSwiftMessage($htmlMessage);
+
+        $embedPlugin = new SwiftEmbedImages($options);
+        $embedPlugin->beforeSendPerformed($this->createSwiftEvent($message));
+
+        return $message;
     }
 }

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Tests;
+namespace Rsvpify\LaravelMailAutoEmbed\Tests;
 
-use Eduardokum\LaravelMailAutoEmbed\Listeners\SwiftEmbedImages;
+use Rsvpify\LaravelMailAutoEmbed\Listeners\SwiftEmbedImages;
 
 class MailTest extends TestCase
 {
@@ -55,7 +55,7 @@ class MailTest extends TestCase
 <!-- url line break     --><img 
                                 src="http://localhost/test.png" 
                             />
-<!--                    entity --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:1" />
+<!--                    entity --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:1" />
 HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'attachment']);
@@ -134,14 +134,18 @@ HTML;
      */
     public function embed_fails_gracefully_with_attachments()
     {
+        config(['mail-auto-embed.whitelist' => [
+            'http://example.com'
+        ]]);
+
         $htmlMessage = <<<HTML
 <!-- host           --><img src="http://example.com/test.png" />
 <!-- image          --><img src="http://localhost/other.png" />
 <!-- source         --><img src="whatever" />
 <!-- syntax         --><img src="embed:whatever" />
 <!-- class          --><img src="embed:WrongEntityClassName:1" />
-<!-- implementation --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1" />
-<!-- not found      --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9" />
+<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1" />
+<!-- not found      --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9" />
 HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'attachment']);
@@ -151,8 +155,8 @@ HTML;
         $this->assertContains('<!-- source         --><img src="whatever',                                                                 $message->getBody());
         $this->assertContains('<!-- syntax         --><img src="embed:whatever',                                                           $message->getBody());
         $this->assertContains('<!-- class          --><img src="embed:WrongEntityClassName:1',                                             $message->getBody());
-        $this->assertContains('<!-- implementation --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1',   $message->getBody());
-        $this->assertContains('<!-- not found      --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9', $message->getBody());
+        $this->assertContains('<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1',   $message->getBody());
+        $this->assertContains('<!-- not found      --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9', $message->getBody());
     }
 
     /**
@@ -166,8 +170,8 @@ HTML;
 <!-- source         --><img src="whatever" />
 <!-- syntax         --><img src="embed:whatever" />
 <!-- class          --><img src="embed:WrongEntityClassName:1" />
-<!-- implementation --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1" />
-<!-- not found      --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9" />
+<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1" />
+<!-- not found      --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9" />
 HTML;
 
         $message = $this->handleBeforeSendPerformedEvent($htmlMessage, ['enabled' => true, 'method' => 'base64']);
@@ -177,8 +181,8 @@ HTML;
         $this->assertContains('<!-- source         --><img src="whatever',                                                                 $message->getBody());
         $this->assertContains('<!-- syntax         --><img src="embed:whatever',                                                           $message->getBody());
         $this->assertContains('<!-- class          --><img src="embed:WrongEntityClassName:1',                                             $message->getBody());
-        $this->assertContains('<!-- implementation --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1',   $message->getBody());
-        $this->assertContains('<!-- not found      --><img src="embed:Eduardokum\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9', $message->getBody());
+        $this->assertContains('<!-- implementation --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\WrongEntity:1',   $message->getBody());
+        $this->assertContains('<!-- not found      --><img src="embed:Rsvpify\\LaravelMailAutoEmbed\\Tests\\fixtures\\PictureEntity:9', $message->getBody());
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,25 +2,30 @@
 
 namespace Rsvpify\LaravelMailAutoEmbed\Tests;
 
+use Illuminate\Foundation\Application;
+use Rsvpify\LaravelMailAutoEmbed\ServiceProvider;
+
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
+     *
      * @return void
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app['path.public'] = __DIR__.'/fixtures';
+        $app['path.public'] = __DIR__ . '/fixtures';
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
+     *
      * @return array
      */
     protected function getPackageProviders($app)
     {
-        return [\Rsvpify\LaravelMailAutoEmbed\ServiceProvider::class];
+        return [ServiceProvider::class];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Tests;
+namespace Rsvpify\LaravelMailAutoEmbed\Tests;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -21,6 +21,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
      */
     protected function getPackageProviders($app)
     {
-        return [\Eduardokum\LaravelMailAutoEmbed\ServiceProvider::class];
+        return [\Rsvpify\LaravelMailAutoEmbed\ServiceProvider::class];
     }
 }

--- a/tests/fixtures/PictureEntity.php
+++ b/tests/fixtures/PictureEntity.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Tests\fixtures;
+namespace Rsvpify\LaravelMailAutoEmbed\Tests\fixtures;
 
-use Eduardokum\LaravelMailAutoEmbed\Models\EmbeddableEntity;
+use Rsvpify\LaravelMailAutoEmbed\Models\EmbeddableEntity;
 
 class PictureEntity implements EmbeddableEntity
 {

--- a/tests/fixtures/WrongEntity.php
+++ b/tests/fixtures/WrongEntity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Eduardokum\LaravelMailAutoEmbed\Tests\fixtures;
+namespace Rsvpify\LaravelMailAutoEmbed\Tests\fixtures;
 
 class WrongEntity
 {

--- a/tests/fixtures/WrongEntity.php
+++ b/tests/fixtures/WrongEntity.php
@@ -4,5 +4,4 @@ namespace Rsvpify\LaravelMailAutoEmbed\Tests\fixtures;
 
 class WrongEntity
 {
-
 }


### PR DESCRIPTION
This PR allows embedding images as attachments even if they're on remote hosts instead of only being on the local server. This is especially useful if for example users are editing emails and images that they embed in the emails are uploaded to Amazon S3 or some other cloud storage solution. Please refer to https://github.com/eduardokum/laravel-mail-auto-embed/issues/13 and @vogelor since I'm just creating a PR with minor modifications to his code.