### PR TITLE
Fixed CodeSniffer being a non-dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "ext-dom": "*",
         "illuminate/contracts": "^5.3 | ^6.0",
         "illuminate/support": "^5.3 | ^6.0",
-        "illuminate/mail": "^5.3 | ^6.0",
-        "squizlabs/php_codesniffer": "^3.5"
+        "illuminate/mail": "^5.3 | ^6.0"
     },
     "require-dev": {
         "php": ">=7.0",
         "orchestra/testbench": "^3.4 | ^4.0",
-        "phpunit/phpunit": "^6.0 | ^7.0 | ^8.0"
+        "phpunit/phpunit": "^6.0 | ^7.0 | ^8.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I missed that I added the `squizlabs/php_codesniffer` library as a normal dependency, instead of a dev-depedency (what it should be).

This, well, solves that.