### PR TITLE
Prevent raw messages to be processed

### DIFF
--- a/src/Listeners/SwiftEmbedImages.php
+++ b/src/Listeners/SwiftEmbedImages.php
@@ -69,11 +69,33 @@ class SwiftEmbedImages implements Swift_Events_SendListener
             return;
         }
 
+        // Invalid HTML (raw message)
+        if ($this->shouldSkipDocument($document)) {
+            return;
+        }
+
         // Add images
         $this->attachImagesToDom($document);
 
         // Replace body
         $this->message->setBody($parser->saveHTML($document));
+    }
+
+    /**
+     * @param  DOMDocument $document
+     * @return bool
+     */
+    private function shouldSkipDocument($document)
+    {
+        if ($document->childNodes->count() != 1) {
+            return false;
+        }
+
+        if ($document->childNodes->item(0)->nodeType == XML_DOCUMENT_TYPE_NODE) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -144,4 +144,17 @@ class MailTest extends TestCase
             $embedPlugin->sendPerformed($this->createSwiftEvent($message))
         );
     }
+
+    /**
+     * @test
+     */
+    public function testDoesntTransformRawMessages()
+    {
+        $message = $this->handleBeforeSendPerformedEvent('raw-message.txt', [
+            'enabled' => true,
+            'method' => 'attachment',
+        ]);
+
+        $this->assertEquals($this->getLibraryFile('raw-message.txt'), $message->getBody());
+    }
 }

--- a/tests/lib/raw-message.txt
+++ b/tests/lib/raw-message.txt
@@ -1,0 +1,2 @@
+The is a raw message that should be skipped.
+It doesn't contain any images.


### PR DESCRIPTION
Hi,

When sending a message using `Mail::raw()`, the HTML5 parser creates a DOMDocument that only contains the doc type, the original content is lost.
This PR allows to skip these kind of messages.

Thanks,
Karel