### PR TITLE
Added option to pass basename thru url parameter

### DIFF
--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -95,8 +95,12 @@ class AttachmentEmbedder extends Embedder
             if ($httpcode == 200) {
                 $pathInfo = pathinfo($url);
 
+                $queryStr = parse_url($url, PHP_URL_QUERY);
+                parse_str($queryStr, $queryParams);
+                $basename = $queryParams['basename'] ?? $pathInfo['basename'];
+
                 return $this->embed(
-                    new Swift_Image($raw, "{$pathInfo['basename']}", $contentType)
+                    new Swift_Image($raw, "{$basename}", $contentType)
                 );
             }
         }


### PR DESCRIPTION
Hi!

Maybe you will be interested in this update / feature. I've added option to pass basename thru url parameter. This is useful when using external url, which has a lot of parameters, because at a moment you would get a very long image name. So this adds ability to pass short&custom image name.