### PR TITLE
Use provided `$name` for embed in symfonyMessage

### DIFF
--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -135,7 +135,6 @@ class AttachmentEmbedder extends Embedder
     protected function embed($body, $name, $type)
     {
         if ($this->isLaravel9() && !empty($this->symfonyMessage)) {
-            $name = Str::random();
             $this->symfonyMessage->embed($body, $name, $type);
             return "cid:$name";
         }


### PR DESCRIPTION
`$name` parameter is mandatory, so I do not understand we need to generate random name here.