### PR TITLE
Add type check for `$name` before resetting it.

### DIFF
--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -135,7 +135,9 @@ class AttachmentEmbedder extends Embedder
     protected function embed($body, $name, $type)
     {
         if ($this->isLaravel9() && !empty($this->symfonyMessage)) {
-            $name = Str::random();
+            if (gettype($name) !== 'string') {
+                $name = Str::random();
+            }
             $this->symfonyMessage->embed($body, $name, $type);
             return "cid:$name";
         }


### PR DESCRIPTION
How about checking type of `$name` before resetting it.

We are loosing functionality of passing file name thru url in Laravel 9