### PR TITLE
Avoid passing null to parse_str() on PHP 8.2

### DIFF
--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -114,7 +114,7 @@ class AttachmentEmbedder extends Embedder
             if ($httpcode == 200) {
                 $pathInfo = pathinfo($url);
 
-                $queryStr = parse_url($url, PHP_URL_QUERY);
+                $queryStr = parse_url($url, PHP_URL_QUERY) ?: '';
                 parse_str($queryStr, $queryParams);
                 $basename = $queryParams['basename'] ?? $pathInfo['basename'];
 


### PR DESCRIPTION
Simple patch to avoid the following message on PHP 8.2:

```
parse_str(): Passing null to parameter #1 ($string) of type string is deprecated
```