### PR TITLE
Prevent empty HTML email when sending raw message with Symfony Mail

### DIFF
--- a/src/Listeners/SymfonyEmbedImages.php
+++ b/src/Listeners/SymfonyEmbedImages.php
@@ -60,6 +60,10 @@ class SymfonyEmbedImages
     {
         // Get body
         $body = $this->message->getHtmlBody();
+        if ($body === null) {
+            // Not an HTML message
+            return;
+        }
 
         // Parse document
         $parser = new HTML5();

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -164,4 +164,24 @@ class MailTest extends TestCase
             ($this->isLaravel9() ? $message->getTextBody() : $message->getBody())
         );
     }
+
+    /**
+     * @test
+     */
+    public function testDoesNotCreateHtmlBodyForSymfonyRawMessage()
+    {
+        if (! $this->isLaravel9()) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $message = $this->handleBeforeSendPerformedEvent(
+            'raw-message.txt',
+            ['enabled' => true, 'method' => 'attachment'],
+            true
+        );
+
+        $this->assertNull($message->getHtmlBody());
+    }
 }

--- a/tests/Traits/InteractsWithMessage.php
+++ b/tests/Traits/InteractsWithMessage.php
@@ -23,17 +23,18 @@ trait InteractsWithMessage
 
     /**
      * @param  string  $htmlMessage
+     * @param  bool    $isRawMessage
      *
      * @return Email|Swift_Message
      */
-    protected function createMessage($htmlMessage)
+    protected function createMessage($htmlMessage, $isRawMessage = false)
     {
         if ($this->isLaravel9()) {
             return (new Email())->to('test@test.com')->from('sender@test.com')->subject('test')
-                ->html($htmlMessage)
-                ->text($htmlMessage);
+                ->text($htmlMessage)
+                ->html($isRawMessage ? null : $htmlMessage);
         } else {
-            return new Swift_Message('test', $htmlMessage);
+            return new Swift_Message('test', $htmlMessage, $isRawMessage ? 'text/plain' : null);
         }
     }
 
@@ -53,12 +54,13 @@ trait InteractsWithMessage
     /**
      * @param  string  $libraryFile
      * @param  array   $options
+     * @param  bool    $isRawMessage
      * @return Swift_Message|Email
      */
-    protected function handleBeforeSendPerformedEvent($libraryFile, $options)
+    protected function handleBeforeSendPerformedEvent($libraryFile, $options, $isRawMessage = false)
     {
         $htmlMessage = $this->getLibraryFile($libraryFile);
-        $message = $this->createMessage($htmlMessage);
+        $message = $this->createMessage($htmlMessage, $isRawMessage);
 
         if ($this->isLaravel9()) {
             $event = new MessageSending($message);


### PR DESCRIPTION
Hi,
When sending a raw mail (`Mail::raw`), the `null` HTML body is replaced by the HTML body doctype (`<!DOCTYPE html>\r\n`). 
As a result, mail clients ignores the raw mail content and only show an empty HTML mail.
Thanks