### PR TITLE
Fix PHP 8.5 deprecation warnings for curl_close

### DIFF
--- a/src/Embedder/AttachmentEmbedder.php
+++ b/src/Embedder/AttachmentEmbedder.php
@@ -136,7 +136,9 @@ class AttachmentEmbedder extends Embedder
             $raw = curl_exec($ch);
             $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
-            curl_close($ch);
+            if (PHP_MAJOR_VERSION < 8) {
+                curl_close($ch);
+            }
 
             if ($httpcode == 200) {
                 $pathInfo = pathinfo($url);

--- a/src/Embedder/Base64Embedder.php
+++ b/src/Embedder/Base64Embedder.php
@@ -74,7 +74,9 @@ class Base64Embedder extends Embedder
             $raw = curl_exec($ch);
             $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
-            curl_close($ch);
+            if (PHP_MAJOR_VERSION < 8) {
+                curl_close($ch);
+            }
 
             if ($httpcode == 200) {
                 return $this->base64String($contentType, $raw);


### PR DESCRIPTION
curl_close is a noop since PHP >= 8, but this project still lists PHP 7 in its composer config.
Support both versions by only calling the function on PHP 7.